### PR TITLE
fix objectName as Number

### DIFF
--- a/src/main/helpers.js
+++ b/src/main/helpers.js
@@ -424,7 +424,7 @@ export const toArray = (param) => {
 
 export const sanitizeObjectKey=(objectName)=>{
   // + symbol characters are not decoded as spaces in JS. so replace them first and decode to get the correct result.
-  let asStrName= (objectName || "").replace(/\+/g, ' ')
+  let asStrName= ((objectName || "") + "").replace(/\+/g, ' ')
   const sanitizedName = decodeURIComponent(asStrName)
   return sanitizedName
 }


### PR DESCRIPTION
When type of object name is Number, there will be a error because no replace method can be found on Number.